### PR TITLE
2019-08-30 GUARD-196 added more logging to SOAP orders sync

### DIFF
--- a/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/Services/Orders/OrdersService.cs
@@ -249,13 +249,13 @@ namespace ChannelAdvisorAccess.Services.Orders
 
 				// If you get message code = 1 (Unexpected)
 				if( results.GetOrderListResult.MessageCode == 1 )
-					resultData = await this.HandleErrorUnexpectedAsync( orderCriteria ).ConfigureAwait( false );
+					resultData = await this.HandleErrorUnexpectedAsync( mark, orderCriteria ).ConfigureAwait( false );
 
 				return resultData;
 			} ).ConfigureAwait( false );
 		}
 
-		private async Task< OrderResponseItem[] > HandleErrorUnexpectedAsync( OrderCriteria orderCriteria, [ CallerMemberName ] string callerMemberName = "" )
+		private async Task< OrderResponseItem[] > HandleErrorUnexpectedAsync( Mark mark, OrderCriteria orderCriteria, [ CallerMemberName ] string callerMemberName = "" )
 		{
 			var result = new List< OrderResponseItem >();
 			var prevPageSize = orderCriteria.PageSize;
@@ -268,7 +268,9 @@ namespace ChannelAdvisorAccess.Services.Orders
 				var numberAttempt = 0;
 				while( numberAttempt < MaxUnexpectedAttempt )
 				{
+					ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );
 					var answer = await this._client.GetOrderListAsync( this._credentials, this.AccountId, orderCriteria ).ConfigureAwait( false );
+					ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodResult : answer.ToJson(), additionalInfo : this.AdditionalLogInfo(), methodParameters : orderCriteria.ToJson() ) );
 					if( answer.GetOrderListResult.Status == ResultStatus.Success )
 					{
 						result.AddRange( answer.GetOrderListResult.ResultData );


### PR DESCRIPTION
**Summary**
To find out the reason why some orders temporarily dissapeared from CA I decided to add logging to method that handles the case when pulling a lot of orders in one request is impossible for some reason.

**Details from logs:**
```
"End call":"{Mark:\"ffc31de7-50c3-43b2-a134-04202d9a5e52\", MethodName:GetOrdersAsync, 
MethodParameters:{
"DetailLevel\":\"Low\",
\"OrderIDList\":[
2611360,2611363,2611365,2611372,2611379,2611381,2611382,2611341,2611527,2611528,2611530,2611529,2611532,2611533,2611536,2611537,2611545,2611546,2611548,2611550,
2611551,2611552,2611554,2611595,2611597,2611599,2611600,2611601,2611604,2611605,2611607,2611626,2611617,2611612,2611613,2611614,2611616,2611619,2611620,2611621,
2611623,2611625,2611627,2611632,2611633,2611645,2611648,2611651,2611653,2611656,2611657,2611662,2611664,2611666,2611668,2611669,2611670,2611671,2611672,2611673,
2611674,2611688,2611690,2611692,2611693,2611698, ! 2611700,2611701,2611702,2611703,2611704,2611705,2611706,2611708,2611713,2611715,2611733,2611735,2611737,2611738,
2611740,2611741,2611742,2611743,2611744,2611745,2611746,2611747,2611749,2611781,2611755,2611756,2611788,2611765,2611769,2611770,2611771,2611809,2611791,2611792,
2611793,2611794,2611814,2611815,2611816,2611817,2611818,2611819,2611820],
\"PageNumberFilter\":110,\"PageSize\":1} , 
Result:
[{\"OrderStatus\":{\"CheckoutStatus\":\"Completed\",\"CheckoutDateGMT\":\"2019-07-30T17:06:52.563\",\"PaymentStatus\": ...
```
SV tried to pull over 100 orders by their Id from CA but in response got only half of them although all orders exist in CA.