### PR TITLE
2019-10-17 GUARD-261 Order-Was-Cancelled

### DIFF
--- a/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Orders/OrdersService.cs
@@ -191,7 +191,7 @@ namespace ChannelAdvisorAccess.REST.Services.Orders
 				clauses.Add( String.Format( "(CheckoutDateUtc ge {0} and CheckoutDateUtc le {1}) or (PaymentDateUtc ge {0} and PaymentDateUtc le {1}) or (ShippingDateUtc ge {0} and ShippingDateUtc le {1}) and ", base.ConvertDate( criteria.StatusUpdateFilterBeginTimeGMT.Value ), base.ConvertDate( criteria.StatusUpdateFilterEndTimeGMT.Value ) ) );
 
 			if ( orderId != null )
-				clauses.Add( String.Format( "SiteOrderID eq '{0}' and ", orderId.Value.ToString() ) );
+				clauses.Add( String.Format( "ID eq {0} and ", orderId.Value.ToString() ) );
 
 			if ( clauses.Count > 0 )
 				clauses[ clauses.Count - 1] = clauses.Last().Substring( 0, clauses.Last().LastIndexOf( "and" ) );

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.0.3.6" ) ]
+[ assembly : AssemblyVersion( "8.0.3.7" ) ]


### PR DESCRIPTION
Summary
One of customer's orders was cancelled in SV by missing orders service because it was not found by it's id.

This happened because REST orders search uses SiteOrderId as filter param instead of ID. When CA pulls order from external system for example Shopify these fields will be different. OnlineSaleId in SV includes CA order ID as part of identificator.