### PR TITLE
2020-04-10 GUARD-398 Update-Library-Version

### DIFF
--- a/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
+++ b/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
@@ -125,8 +125,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
+    <Reference Include="CsvHelper, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvHelper.12.0.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="CuttingEdge.Conditions">
       <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>

--- a/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/Items/ItemsService.cs
@@ -1194,6 +1194,7 @@ namespace ChannelAdvisorAccess.REST.Services.Items
 							{
 								csvReader.Configuration.HasHeaderRecord = true;
 								csvReader.Configuration.Delimiter = "\t";
+								csvReader.Configuration.BadDataFound = null;
 
 								var rows = csvReader.GetRecords< ProductExportRow >();
 								var productIds = new Dictionary< string, int >();

--- a/src/ChannelAdvisorAccess/packages.config
+++ b/src/ChannelAdvisorAccess/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsvHelper" version="2.16.3.0" targetFramework="net451" />
+  <package id="CsvHelper" version="12.0.0" targetFramework="net451" />
   <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net40" />
   <package id="Netco" version="1.5.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.5.2.0" ) ]
+[ assembly : AssemblyVersion( "8.5.3.0" ) ]


### PR DESCRIPTION
Summary
Pointed CsvHelper access library to version 12.0.0.