### PR TITLE
2020-06-08 GUARD-636 Change-API-Retry-Time

### DIFF
--- a/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ItemsServiceItems.cs
@@ -1028,7 +1028,7 @@ namespace ChannelAdvisorAccess.Services.Items
 				ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, additionalInfo : this.AdditionalLogInfo(), methodParameters : skus.ToJson() ) );
 
 				var skusParts = ToChunks( skus, 100 );
-				var inventoryQuantityResponses = ( await skusParts.ProcessInBatchAsync( 3, async s =>
+				var inventoryQuantityResponses = ( await skusParts.ProcessInBatchAsync( 1, async s =>
 				{
 					var requestResult = await AP.CreateQueryAsync( ExtensionsInternal.CreateMethodCallInfo( this.AdditionalLogInfo ) ).Get( async () =>
 					{

--- a/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
+++ b/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="Inventory\DistributionCenterTests.cs" />
     <Compile Include="Inventory\ItemsServiceTests.cs" />
+    <Compile Include="Misc\ActionPolicyTests.cs" />
     <Compile Include="Misc\OrderExtensionsTests.cs" />
     <Compile Include="Orders\OrdersServiceTests.cs" />
     <Compile Include="REST\Inventory\DistributionCenterTests.cs" />

--- a/src/ChannelAdvisorAccessTests/Misc/ActionPolicyTests.cs
+++ b/src/ChannelAdvisorAccessTests/Misc/ActionPolicyTests.cs
@@ -1,0 +1,30 @@
+﻿using ChannelAdvisorAccess.Misc;
+using ChannelAdvisorAccess.REST.Shared;
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+
+namespace ChannelAdvisorAccessTests.Misc
+{
+	[ TestFixture ]
+	public class ActionPolicyTests
+	{
+		[ Test ]
+		public void WaitRetryTimeWhenRestApiIsUsedShouldntExceedTenMinutes()
+		{
+			var actionPolicy = new ActionPolicy( 10 );
+			var retryWaitTime = actionPolicy.GetDelayBeforeNextAttempt( 10 );
+
+			retryWaitTime.Should().Be( TimeSpan.FromMinutes( 10 ) );
+		}
+
+		[ Test ]
+		public void WaitRetryTimeWhenSoapApiIsUsedShouldntExceedTenMinutes()
+		{
+			var attemptNumber = 10;
+			var retryWaitTime = AP.GetDelayFor429Exception( attemptNumber );
+
+			retryWaitTime.Should().Be( TimeSpan.FromMinutes( 10 ) );
+		}
+	}
+}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.5.7.0" ) ]
+[ assembly : AssemblyVersion( "8.5.9.0" ) ]


### PR DESCRIPTION
Summary
Changed retry time calculation logic for REST and SOAP API.

SOAP API
Before: if SV receives 429 HTTP error after 5 retry attempt, the thread will wait for the rest of the hour. I guess that this logic somehow relates to hour quota limits.
After: exponential wait time is used, max wait time will be 10 minutes.

REST API
Just refactored code to make sure that 10 minutes will never be exceeded.