### PR TITLE
2020-07-03 GUARD-667 Secure-Channel-Setup-Error

### DIFF
--- a/src/ChannelAdvisorAccess/Services/ChannelAdvisorServicesFactory.cs
+++ b/src/ChannelAdvisorAccess/Services/ChannelAdvisorServicesFactory.cs
@@ -38,7 +38,6 @@ namespace ChannelAdvisorAccess.Services
 
 		public IAdminService CreateAdminService()
 		{
-			SetSecurityProtocol();
 			var adminCredentials = new AdminService.APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			return new Admin.AdminService( adminCredentials );
 		}
@@ -64,7 +63,6 @@ namespace ChannelAdvisorAccess.Services
 		/// <returns></returns>
 		public IOrdersService CreateOrdersService( string accountName, string accountId )
 		{
-			SetSecurityProtocol();
 			var ordersCredentials = new APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			return new OrdersService( ordersCredentials, accountName, accountId, this._cache );
 		}
@@ -78,7 +76,6 @@ namespace ChannelAdvisorAccess.Services
 		/// <returns></returns>
 		public IOrdersService CreateOrdersRestServiceWithSoapCompatibleAuth( string accountName, string accountId, IItemsService itemsService )
 		{
-			SetSecurityProtocol();
 			var credentials = new RestCredentials( this._applicationId, this._sharedSecret );
 			var soapCredentials = new APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			
@@ -96,8 +93,6 @@ namespace ChannelAdvisorAccess.Services
 		/// <returns></returns>
 		public IOrdersService CreateOrdersRestService( string accountName, string accountId, string accessToken, string refreshToken, bool soapCompatibleAuth = false )
 		{
-			SetSecurityProtocol();
-
 			var credentials = new RestCredentials( this._applicationId, this._sharedSecret );
 
 			if ( soapCompatibleAuth )
@@ -133,8 +128,6 @@ namespace ChannelAdvisorAccess.Services
 		/// <returns></returns>
 		public IItemsService CreateItemsService( string accountName, string accountId )
 		{
-			SetSecurityProtocol();
-
 			var inventoryCredentials = new InventoryService.APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			return new ItemsService( inventoryCredentials, accountName, accountId, this._cache ){ SlidingCacheExpiration = this._slidingCacheExpiration };
 		}
@@ -174,23 +167,14 @@ namespace ChannelAdvisorAccess.Services
 
 		public IShippingService CreateShippingService( string accountName, string accountId )
 		{
-			SetSecurityProtocol();
 			var shippingCredentials = new ShippingService.APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			return new Shipping.ShippingService( shippingCredentials, accountName, accountId );
 		}
 
 		public IListingService CreateListingService( string accountName, string accountId )
 		{
-			SetSecurityProtocol();
 			var listingCredentials = new ListingService.APICredentials { DeveloperKey = this._developerKey, Password = this._developerPassword };
 			return new Listing.ListingService( listingCredentials, accountName, accountId );
 		}
-
-		#region SSL certificate hack
-		public static void SetSecurityProtocol()
-		{
-			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
-		}
-		#endregion
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.5.8.0" ) ]
+[ assembly : AssemblyVersion( "8.6.0.0" ) ]


### PR DESCRIPTION
**Summary**
Removed set security protocol code due to possible conflicts with other integrations. For example, some integrations like NetSuite or QBO use only TLS 1.2 and higher.