### PR TITLE
GUARD-742 Inventory Sync Stuck

### DIFF
--- a/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
+++ b/src/ChannelAdvisorAccess/ChannelAdvisorAccess.csproj
@@ -207,6 +207,7 @@
     <Compile Include="REST\Exceptions\ChannelAdvisorNetworkException.cs" />
     <Compile Include="REST\Exceptions\ChannelAdvisorProductExportFailedException.cs" />
     <Compile Include="REST\Models\Configuration\ChannelAdvisorEndPoint.cs" />
+    <Compile Include="REST\Models\Infrastructure\BatchResponses.cs" />
     <Compile Include="REST\Models\Infrastructure\OAuthResponse.cs" />
     <Compile Include="REST\Models\Infrastructure\ProductExportResponse.cs" />
     <Compile Include="REST\Models\Infrastructure\ProductExportRow.cs" />

--- a/src/ChannelAdvisorAccess/Misc/ChannelAdvisorLogger.cs
+++ b/src/ChannelAdvisorAccess/Misc/ChannelAdvisorLogger.cs
@@ -7,7 +7,7 @@ using Netco.Logging;
 
 namespace ChannelAdvisorAccess.Misc
 {
-	internal class ChannelAdvisorLogger
+	public class ChannelAdvisorLogger
 	{
 		private static readonly string _versionInfo;
 		private const string CaMark = "channelAdvisor";
@@ -89,6 +89,12 @@ namespace ChannelAdvisorAccess.Misc
 		{
 			return Enumerable.Range( 0, str.Length / chunkSize )
 				.Select( i => str.Substring( i * chunkSize, chunkSize ) );
+		}
+
+		public static string SanitizeToken( string token )
+		{
+			var length = token.Length;
+			return token.Substring( 0, Math.Min( 4, length ) ) + "****" + token.Substring( length - Math.Min( 4, length ) ); 
 		}
 	}
 }

--- a/src/ChannelAdvisorAccess/REST/Models/Infrastructure/BatchResponses.cs
+++ b/src/ChannelAdvisorAccess/REST/Models/Infrastructure/BatchResponses.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ChannelAdvisorAccess.REST.Models.Infrastructure
+{
+	public class BatchResponses< T >
+	{
+		[ JsonProperty( "responses" ) ]
+		public IEnumerable< BatchResponse< T > > Responses { get; set; }
+	}
+
+	public class BatchResponse< T >
+	{
+		[ JsonProperty( "id" ) ]
+		public string Id { get; set; }
+
+		[ JsonProperty( "status" ) ]
+		public int Status { get; set; }
+
+		[ JsonProperty( "headers" ) ]
+		public object Headers { get; set; }
+
+		[ JsonProperty( "body" ) ]
+		public T Body { get; set; }
+	}
+}

--- a/src/ChannelAdvisorAccess/REST/Models/Infrastructure/ODataResponse.cs
+++ b/src/ChannelAdvisorAccess/REST/Models/Infrastructure/ODataResponse.cs
@@ -16,5 +16,16 @@ namespace ChannelAdvisorAccess.REST.Models.Infrastructure
 		public string NextLink { get; set; }
 		[ JsonProperty( PropertyName = "@odata.count" ) ]
 		public int? Count { get; set; }
+		[ JsonProperty( "error" ) ]
+		public ResponseError Error { get; set; }
+	}
+
+	public class ResponseError
+	{
+		[ JsonProperty( "code" ) ]
+		public string Code { get; set; }
+	
+		[ JsonProperty( "message" ) ]
+		public string Message { get; set; }
 	}
 }

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -547,7 +547,7 @@ namespace ChannelAdvisorAccess.REST.Services
 							string content = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait( false );
 
 							int batchStatusCode;
-							entities.AddRange( new MultiPartResponseParser().Parse< T >( content, out batchStatusCode ) );
+							entities.AddRange( MultiPartResponseParser.Parse< T >( content, out batchStatusCode ) );
 
 							if ( (int)httpResponse.StatusCode == _tooManyRequestsStatusCode )
 							{

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -135,13 +135,14 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// <summary>
 		///	Gets refresh token via developer console credentials
 		/// </summary>
+		/// <param name="mark">Mark for logging</param>
 		/// <returns></returns>
-		private Task RefreshAccessToken()
+		private Task RefreshAccessToken( Mark mark )
 		{
 			if ( string.IsNullOrEmpty( this._accessToken ) )
 				return this.RefreshAccessTokenBySoapCredentials();
 			else
-				return this.RefreshAccessTokenByRestCredentials();
+				return this.RefreshAccessTokenByRestCredentials( mark );
 		}
 
 		/// <summary>
@@ -194,18 +195,24 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// <summary>
 		///	Gets refresh token by REST credentials
 		/// </summary>
+		/// <param name="mark">Mark for logging</param>
 		/// <returns></returns>
-		private async Task RefreshAccessTokenByRestCredentials()
+		private async Task RefreshAccessTokenByRestCredentials( Mark mark )
 		{
 			_waitHandle.WaitOne();
 			this.SetBasicAuthorizationHeader();
+			AddAccountInfoToHeader();
 
 			var requestData = new Dictionary< string, string > { { "grant_type", "refresh_token" }, { "refresh_token", this._refreshToken } };
 			var content = new FormUrlEncodedContent( requestData );
+			const string requestTokenUrl = "oauth2/token";
+
+			var payloadForLog = new { GrantType = requestData[ "grant_type" ], RefreshToken = ChannelAdvisorLogger.SanitizeToken( requestData[ "refresh_token" ] ) };
+			ChannelAdvisorLogger.LogStarted( this.CreateMethodCallInfo( mark : mark, methodParameters: requestTokenUrl, payload: payloadForLog.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 
 			try
 			{
-				var response = await this.HttpClient.PostAsync( "oauth2/token", content ).ConfigureAwait( false );
+				var response = await this.HttpClient.PostAsync( requestTokenUrl, content ).ConfigureAwait( false );
 				var responseStr = await response.Content.ReadAsStringAsync().ConfigureAwait( false );
 				var result = JsonConvert.DeserializeObject< OAuthResponse >( responseStr );
 
@@ -214,6 +221,9 @@ namespace ChannelAdvisorAccess.REST.Services
 
 				this._accessToken = result.AccessToken;
 				this._accessTokenExpiredUtc = DateTime.UtcNow.AddSeconds( result.ExpiresIn );
+
+				var resultForLog = new { AccessToken = ChannelAdvisorLogger.SanitizeToken( result.AccessToken ), result.Error, ExpiresOn = this._accessTokenExpiredUtc };
+				ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: requestTokenUrl, methodResult: resultForLog.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 			}
 			catch( Exception ex )
 			{
@@ -225,6 +235,15 @@ namespace ChannelAdvisorAccess.REST.Services
 				_waitHandle.Set();
 				this.SetDefaultAuthorizationHeader();
 			}
+		}
+
+		private void AddAccountInfoToHeader()
+		{
+			if( !this.HttpClient.DefaultRequestHeaders.Contains( "account_name" ) )
+				this.HttpClient.DefaultRequestHeaders.Add( "account_name", this.AccountName );
+
+			if( !this.HttpClient.DefaultRequestHeaders.Contains( "account_id" ) )
+				this.HttpClient.DefaultRequestHeaders.Add( "account_id", this.AccountId );
 		}
 
 		/// <summary>
@@ -351,7 +370,7 @@ namespace ChannelAdvisorAccess.REST.Services
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: responseStr, additionalInfo : this.AdditionalLogInfo() ) );
 
-							await this.ThrowIfError( httpResponse, responseStr ).ConfigureAwait( false );
+							await this.ThrowIfError( httpResponse, responseStr, mark ).ConfigureAwait( false );
 					
 							var message = JsonConvert.DeserializeObject< T >( responseStr );
 
@@ -404,7 +423,7 @@ namespace ChannelAdvisorAccess.REST.Services
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: responseStr, additionalInfo : this.AdditionalLogInfo() ) );
 
-							await this.ThrowIfError( httpResponse, responseStr ).ConfigureAwait( false );
+							await this.ThrowIfError( httpResponse, responseStr, mark ).ConfigureAwait( false );
 
 							var message = JsonConvert.DeserializeObject< T >( responseStr );
 
@@ -443,7 +462,7 @@ namespace ChannelAdvisorAccess.REST.Services
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: apiUrl, additionalInfo : this.AdditionalLogInfo() ) );
 							
-							await this.ThrowIfError( httpResponse, null ).ConfigureAwait( false );
+							await this.ThrowIfError( httpResponse, null, mark ).ConfigureAwait( false );
 
 							return httpResponse.StatusCode;
 						}
@@ -481,7 +500,7 @@ namespace ChannelAdvisorAccess.REST.Services
 
 						ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: apiUrl, additionalInfo : this.AdditionalLogInfo() ) );
 							
-						await this.ThrowIfError( httpResponse, null ).ConfigureAwait( false );
+						await this.ThrowIfError( httpResponse, null, mark ).ConfigureAwait( false );
 
 						return httpResponse.StatusCode;
 					}
@@ -558,7 +577,7 @@ namespace ChannelAdvisorAccess.REST.Services
 								}
 							}
 
-							await this.ThrowIfError( batchStatusCode, content ).ConfigureAwait( false );
+							await this.ThrowIfError( batchStatusCode, content, mark ).ConfigureAwait( false );
 
 							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: content.ToJson(), additionalInfo : this.AdditionalLogInfo() ) );
 						}
@@ -578,7 +597,8 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// </summary>
 		/// <param name="response"></param>
 		/// <param name="message">response message from server</param>
-		private async Task ThrowIfError( HttpResponseMessage response, string message )
+		/// <param name="mark">mark for logging</param>
+		private async Task ThrowIfError( HttpResponseMessage response, string message, Mark mark )
 		{
 			if ( response.IsSuccessStatusCode )
 				return;
@@ -586,10 +606,10 @@ namespace ChannelAdvisorAccess.REST.Services
 			if ( message == null )
 				message = await response.Content.ReadAsStringAsync().ConfigureAwait( false );
 
-			await ThrowIfError( (int)response.StatusCode, message ).ConfigureAwait( false );
+			await ThrowIfError( (int)response.StatusCode, message, mark ).ConfigureAwait( false );
 		}
 
-		private async Task ThrowIfError( int responseStatusCode, string message )
+		private async Task ThrowIfError( int responseStatusCode, string message, Mark mark )
 		{
 			if ( responseStatusCode >= 200 && responseStatusCode < 300 )
 				return;
@@ -597,7 +617,7 @@ namespace ChannelAdvisorAccess.REST.Services
 			if ( responseStatusCode == (int)HttpStatusCode.Unauthorized )
 			{
 				// we have to refresh our access token
-				await this.RefreshAccessToken().ConfigureAwait( false );
+				await this.RefreshAccessToken( mark ).ConfigureAwait( false );
 
 				throw new ChannelAdvisorUnauthorizedException( message );
 			}

--- a/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
+++ b/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
@@ -1,65 +1,18 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using ChannelAdvisorAccess.REST.Models.Infrastructure;
+using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 
 namespace ChannelAdvisorAccess.REST.Shared
 {
-	public class MultiPartResponseParser
+	public static class MultiPartResponseParser
 	{
-		private const string PartDelimiter = "batchresponse";
-
-		public IEnumerable< T > Parse< T >( string response, out int httpBatchStatusCode )
+		public static IEnumerable< T > Parse< T >( string response, out int httpBatchStatusCode )
 		{
-			httpBatchStatusCode = (int)HttpStatusCode.OK;
-			var result = new List< T >();
-
-			string[] lines = response.Split( new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries );
-			string partResponseRaw = null;
-			var startPick = false;
-
-			for( int i = 0; i < lines.Length; i++ )
-			{
-				var line = lines[ i ];
-				if ( line.Contains( PartDelimiter ) )
-				{
-					if ( partResponseRaw != null )
-					{
-						try
-						{
-							result.Add( JsonConvert.DeserializeObject< T >( partResponseRaw ) );
-						}
-						catch { }
-					}
-
-					partResponseRaw = null;
-					startPick = false;
-				}
-				else if ( line.Contains( "HTTP/1.1" ) )
-				{
-					var temp = line.Replace( "HTTP/1.1", "" ).Split( new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries );
-
-					if ( temp.Length > 0 )
-					{
-						int httpRequestStatusCode = 0;
-						if ( int.TryParse( temp[0], out httpRequestStatusCode ) )
-						{
-							if ( httpRequestStatusCode >= 300 )
-								httpBatchStatusCode = httpRequestStatusCode;
-						}
-					}
-				}
-				else if ( line.Contains( "Data-Version" ) )
-				{
-					startPick = true;
-					continue;
-				}
-
-				if ( startPick )
-					partResponseRaw += line;
-			}
-
-			return result;
+			var batchResponses = JsonConvert.DeserializeObject< BatchResponses< T > >( response )?.Responses;
+			httpBatchStatusCode = batchResponses?.ToList().Last().Status ?? ( int ) HttpStatusCode.OK;
+			return batchResponses?.ToList().Select( x => x.Body ) ?? new List<T>();
 		}
 	}
 }

--- a/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
+++ b/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
@@ -10,9 +10,12 @@ namespace ChannelAdvisorAccess.REST.Shared
 	{
 		public static IEnumerable< T > Parse< T >( string response, out int httpBatchStatusCode )
 		{
-			var batchResponses = JsonConvert.DeserializeObject< BatchResponses< T > >( response )?.Responses;
-			httpBatchStatusCode = batchResponses?.ToList().Last().Status ?? ( int ) HttpStatusCode.OK;
-			return batchResponses?.ToList().Select( x => x.Body ) ?? new List<T>();
+			var batchResponses = JsonConvert.DeserializeObject< BatchResponses< T > >( response );
+			var batchResponsesList = ( batchResponses != null && batchResponses.Responses != null ) ? 
+				batchResponses.Responses.ToList() : new List< BatchResponse< T > >();
+			var lastResponseItem = batchResponsesList.LastOrDefault();
+			httpBatchStatusCode = ( lastResponseItem != null ) ? lastResponseItem.Status : ( int ) HttpStatusCode.OK;
+			return batchResponsesList.Select( x => x.Body ) ?? new List< T >();
 		}
 	}
 }

--- a/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
+++ b/src/ChannelAdvisorAccess/REST/Shared/MultiPartResponseParser.cs
@@ -13,8 +13,8 @@ namespace ChannelAdvisorAccess.REST.Shared
 			var batchResponses = JsonConvert.DeserializeObject< BatchResponses< T > >( response );
 			var batchResponsesList = ( batchResponses != null && batchResponses.Responses != null ) ? 
 				batchResponses.Responses.ToList() : new List< BatchResponse< T > >();
-			var lastResponseItem = batchResponsesList.LastOrDefault();
-			httpBatchStatusCode = ( lastResponseItem != null ) ? lastResponseItem.Status : ( int ) HttpStatusCode.OK;
+			var lastItemWithStatus300AndUp = batchResponsesList.LastOrDefault( x => x.Status >= 300 );
+			httpBatchStatusCode = ( lastItemWithStatus300AndUp != null ) ? lastItemWithStatus300AndUp.Status : ( int ) HttpStatusCode.OK;
 			return batchResponsesList.Select( x => x.Body ) ?? new List< T >();
 		}
 	}

--- a/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
+++ b/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="Inventory\DistributionCenterTests.cs" />
     <Compile Include="Inventory\ItemsServiceTests.cs" />
+    <Compile Include="Misc\ChannelAdvisorLoggerTests.cs" />
     <Compile Include="Misc\OrderExtensionsTests.cs" />
     <Compile Include="Orders\OrdersServiceTests.cs" />
     <Compile Include="REST\Inventory\DistributionCenterTests.cs" />

--- a/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
+++ b/src/ChannelAdvisorAccessTests/ChannelAdvisorAccessTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="REST\Orders\OrdersServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="REST\RestAPITestBase.cs" />
+    <Compile Include="REST\Shared\MultiPartResponseParserTests.cs" />
     <Compile Include="REST\Shared\SoapAdapterTests.cs" />
     <Compile Include="TestsBase.cs" />
   </ItemGroup>

--- a/src/ChannelAdvisorAccessTests/Misc/ChannelAdvisorLoggerTests.cs
+++ b/src/ChannelAdvisorAccessTests/Misc/ChannelAdvisorLoggerTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using ChannelAdvisorAccess.Misc;
+
+namespace ChannelAdvisorAccessTests.Misc
+{
+	[ TestFixture ]
+	public class ChannelAdvisorLoggerTests
+	{
+		[ Test ]
+		public void SanitizeToken_Long()
+		{
+			string token = "12345689012345";
+
+			var result = ChannelAdvisorLogger.SanitizeToken( token );
+
+			result.Should().Be( "1234****2345" );
+		}
+
+		[ Test ]
+		public void SanitizeToken_Short()
+		{
+			string token = "123456";
+
+			var result = ChannelAdvisorLogger.SanitizeToken( token );
+
+			result.Should().Be( "1234****3456" );
+		}
+	}
+}

--- a/src/ChannelAdvisorAccessTests/REST/Shared/MultiPartResponseParserTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Shared/MultiPartResponseParserTests.cs
@@ -1,0 +1,58 @@
+﻿using ChannelAdvisorAccess.REST.Models;
+using ChannelAdvisorAccess.REST.Models.Infrastructure;
+using ChannelAdvisorAccess.REST.Shared;
+using FluentAssertions;
+using NUnit.Framework;
+using System.Linq;
+using System.Net;
+
+namespace ChannelAdvisorAccessTests.REST.Shared
+{
+	[ TestFixture ]
+	public class MultiPartResponseParserTests
+	{
+		const string responseProductsSuccess = "{\"responses\":[{\"id\":\"1\",\"status\":200,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"@odata.context\":\"https://api.channeladvisor.com/v1/$metadata#Products(ID,Sku)\",\"value\":[{\"ID\":10062976,\"Sku\":\"testkit1\"},{\"ID\":11111111,\"Sku\":\"testsku1\"}]}},{\"id\":\"2\",\"status\":200,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"@odata.context\":\"https://api.channeladvisor.com/v1/$metadata#Products(ID,Sku)\",\"value\":[{\"ID\":10059896,\"Sku\":\"testkit2\"},{\"ID\":22222222,\"Sku\":\"testsku2\"}]}}]}";
+
+		[ Test ]
+		public void GivenBatchItemsReturn200Status_WhenCallMultiPartResponseParser_ThenReturns200BatchStatusCode()
+		{
+			int batchStatusCode;
+			const int success = ( int ) HttpStatusCode.OK;
+
+			MultiPartResponseParser.Parse< ODataResponse< Product > >( responseProductsSuccess, out batchStatusCode );
+
+			batchStatusCode.Should().Be( success );
+		}
+		
+		[ Test ]
+		public void GivenBatchItemsProducts_WhenCallMultiPartResponseParser_ThenParsesProducts()
+		{
+			int batchStatusCode;
+
+			var result = MultiPartResponseParser.Parse< ODataResponse< Product > >( responseProductsSuccess, out batchStatusCode ).ToList();
+
+			result.Count().Should().Be( 2 );
+			result[ 0 ].Value[ 0 ].ID.Should().Be( 10062976 );
+			result[ 0 ].Value[ 0 ].Sku.Should().Be( "testkit1" );
+			result[ 0 ].Value[ 1 ].ID.Should().Be( 11111111 );
+			result[ 0 ].Value[ 1 ].Sku.Should().Be( "testsku1" );
+			result[ 1 ].Value[ 0 ].ID.Should().Be( 10059896 );
+			result[ 1 ].Value[ 0 ].Sku.Should().Be( "testkit2" );
+			result[ 1 ].Value[ 1 ].ID.Should().Be( 22222222 );
+			result[ 1 ].Value[ 1 ].Sku.Should().Be( "testsku2" );
+		}
+
+		[ Test ]
+		public void GivenBatchItemsReturn401Status_WhenCallMultiPartResponseParser_ThenReturns401BatchStatusCode()
+		{
+			int batchStatusCode;
+			const int unauthorized401 = ( int ) HttpStatusCode.Unauthorized;
+			var responseItemsStatus401 = "{\"responses\":[{\"id\":\"1\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"2\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"3\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"4\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"5\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"6\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}}]}";
+
+			var result = MultiPartResponseParser.Parse< ODataResponse< Product > >( responseItemsStatus401, out batchStatusCode ).ToList();
+
+			batchStatusCode.Should().Be( unauthorized401 );
+			result[ 0 ].Error.Message.Should().Be( "Authorization has been denied for this request." );
+		}
+	}
+}

--- a/src/ChannelAdvisorAccessTests/REST/Shared/MultiPartResponseParserTests.cs
+++ b/src/ChannelAdvisorAccessTests/REST/Shared/MultiPartResponseParserTests.cs
@@ -54,5 +54,19 @@ namespace ChannelAdvisorAccessTests.REST.Shared
 			batchStatusCode.Should().Be( unauthorized401 );
 			result[ 0 ].Error.Message.Should().Be( "Authorization has been denied for this request." );
 		}
+
+		[ Test ]
+		public void GivenSomeItemsHave401StatusButLastOneHas200_WhenCallMultiPartResponseParser_ThenReturns401BatchStatusCode()
+		{
+			int batchStatusCode;
+			const int unauthorized401 = ( int ) HttpStatusCode.Unauthorized;
+			var responseItems401TheLast200 = "{\"responses\":[{\"id\":\"1\",\"status\":500,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"2\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"3\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"4\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"5\",\"status\":401,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"error\":{\"code\":\"\",\"message\":\"Authorization has been denied for this request.\"}}},{\"id\":\"6\",\"status\":200,\"headers\":{\"content-type\":\"application/json; odata.metadata=minimal; odata.streaming=true\",\"odata-version\":\"4.0\"}, \"body\" :{\"@odata.context\":\"https://api.channeladvisor.com/v1/$metadata#Products(ID,Sku)\",\"value\":[{\"ID\":10059896,\"Sku\":\"testkit2\"},{\"ID\":22222222,\"Sku\":\"testsku2\"}]}}]}";
+
+			var result = MultiPartResponseParser.Parse< ODataResponse< Product > >( responseItems401TheLast200, out batchStatusCode ).ToList();
+
+			batchStatusCode.Should().Be( unauthorized401 );
+			result[ 0 ].Error.Message.Should().Be( "Authorization has been denied for this request." );
+			result[ 5 ].Value.First().Sku.Should().Be( "testkit2" );
+		}
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.7.2.0" ) ]
+[ assembly : AssemblyVersion( "8.7.3.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.7.1.0" ) ]
+[ assembly : AssemblyVersion( "8.7.2.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.6.0.0" ) ]
+[ assembly : AssemblyVersion( "8.7.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.7.3.0" ) ]
+[ assembly : AssemblyVersion( "8.7.4.0" ) ]


### PR DESCRIPTION
Channel Advisor changed the format of the batch response we use for REST. As result our batch response parser was no longer detecting 401 unauthorized (invalid access token) and therefore wasn't attempting to get the new token, and then retry getting products by sku's and then pushing inventory. Updated the parser to handle the new format.

Also, added logging of requests for a new token, with the tokens partially obscured, for security. Pass the channel account account name with the request (in the header) for easier troubleshooting on Channel Advisor's side.