### PR TITLE
GUARD-842 Order Sync Stuck

### DIFF
--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -376,7 +376,7 @@ namespace ChannelAdvisorAccess.REST.Services
 							var httpResponse = await this.HttpClient.GetAsync( url, cancellationTokenSource.Token ).ConfigureAwait( false );
 							var responseStr = await httpResponse.Content.ReadAsStringAsync();
 
-							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: responseStr, additionalInfo : this.AdditionalLogInfo() ) );
+							ChannelAdvisorLogger.LogEnd( this.CreateMethodCallInfo( mark : mark, methodParameters: url, methodResult: responseStr, returnStatusCode: httpResponse.StatusCode.ToString(), additionalInfo : this.AdditionalLogInfo() ) );
 
 							await this.ThrowIfError( httpResponse, responseStr, mark ).ConfigureAwait( false );
 					

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -608,9 +608,6 @@ namespace ChannelAdvisorAccess.REST.Services
 		/// <param name="mark">mark for logging</param>
 		private async Task ThrowIfError( HttpResponseMessage response, string message, Mark mark )
 		{
-			if ( response.IsSuccessStatusCode )
-				return;
-
 			if ( message == null )
 				message = await response.Content.ReadAsStringAsync().ConfigureAwait( false );
 

--- a/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/REST/Services/ServiceBaseAbstr.cs
@@ -616,7 +616,7 @@ namespace ChannelAdvisorAccess.REST.Services
 
 		private async Task ThrowIfError( int responseStatusCode, string message, Mark mark )
 		{
-			var isUnauthorized = message == "{\"$id\":\"1\",\"Message\":\"Authorization has been denied for this request.\"}";
+			var isUnauthorized = message.ToUpperInvariant().Contains( "MESSAGE\":\"AUTHORIZATION HAS BEEN DENIED FOR THIS REQUEST.\"" );
 			if ( responseStatusCode >= 200 && responseStatusCode < 300 && !isUnauthorized )
 				return;
 

--- a/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
+++ b/src/ChannelAdvisorAccess/Services/Items/ServiceBaseAbstr.cs
@@ -7,14 +7,14 @@ namespace ChannelAdvisorAccess.Services.Items
 {
 	public abstract class ServiceBaseAbstr
 	{
-		protected string CreateMethodCallInfo( string methodParameters = "", string payload = "", Mark mark = null, string errors = "", string methodResult = "", string additionalInfo = "", string notes = "", [ CallerMemberName ] string memberName = "" )
+		protected string CreateMethodCallInfo( string methodParameters = "", string payload = "", Mark mark = null, string errors = "", string methodResult = "", string additionalInfo = "", string notes = "", [ CallerMemberName ] string memberName = "", string returnStatusCode = "" )
 		{
 			try
 			{
 				mark = mark ?? Mark.Blank();
 				var connectionInfo = this.ToJson();
 				var str = string.Format(
-					"{{Mark:\"{3}\", MethodName:{0}, ConnectionInfo:{1}, MethodParameters: {2} {8}{4}{5}{6}{7}}}",
+					"{{Mark:\"{3}\", MethodName:{0}, ConnectionInfo:{1}, MethodParameters: {2} {8}{4}{5}{6}{7}{9}}}",
 					memberName,
 					connectionInfo,
 					string.IsNullOrWhiteSpace( methodParameters ) ? PredefinedValues.EmptyJsonObject : methodParameters,
@@ -23,7 +23,8 @@ namespace ChannelAdvisorAccess.Services.Items
 					string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult,
 					string.IsNullOrWhiteSpace( notes ) ? string.Empty : ",Notes: " + notes,
 					string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", AdditionalInfo: " + additionalInfo,
-					string.IsNullOrWhiteSpace( payload ) ? string.Empty : ", Body: " + payload
+					string.IsNullOrWhiteSpace( payload ) ? string.Empty : ", Body: " + payload,
+					string.IsNullOrWhiteSpace( returnStatusCode ) ? string.Empty : ", ReturnStatus: \"" + returnStatusCode + "\""
 					);
 				return str;
 			}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.9.0.0" ) ]
+[ assembly : AssemblyVersion( "8.9.1.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 // Keep in track with CA API version
-[ assembly : AssemblyVersion( "8.7.4.0" ) ]
+[ assembly : AssemblyVersion( "8.9.0.0" ) ]


### PR DESCRIPTION
- Will now throw Unauthorized exception if the return contents contain "MESSAGE\":\"AUTHORIZATION HAS BEEN DENIED FOR THIS REQUEST.\"" even if the return code is 200 Ok. This seems to be happening for REST with SOAP compatibility when Orders Sync calls GetEntityAsync< T >, causing our code to not throw the exception and not refresh the token.
- Added logging for refreshing the token under SOAP (also used in REST with SOAP compatibility).
- Added logging of response code in GetEntityAsync< T > to better troubleshoot this issue.